### PR TITLE
feat: add `existingSecret` param for Github

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.11.2
+version: 17.11.3
 appVersion: 22.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -511,4 +511,26 @@ Common Sentry environment variables
       name: {{ .Values.slack.existingSecret }}
       key: "signing-secret"
 {{- end }}
+{{- if and .Values.github.existingSecret }}
+- name: GITHUB_APP_PRIVATE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.github.existingSecret }}
+      key: {{ default "private-key" .Values.github.existingSecretPrivateKeyKey }}
+- name: GITHUB_APP_WEBHOOK_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.github.existingSecret }}
+      key: {{ default "webhook-secret" .Values.github.existingSecretWebhookSecretKey }}
+- name: GITHUB_APP_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.github.existingSecret }}
+      key: {{ default "client-id" .Values.github.existingSecretClientIdKey }}
+- name: GITHUB_APP_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.github.existingSecret }}
+      key: {{ default "client-secret" .Values.github.existingSecretClientSecretKey }}
+{{- end }}
 {{- end -}}

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -31,24 +31,25 @@ data:
     ##########
     # Github #
     ##########
-    {{- if .Values.github.appId }}
-    github-app.id: {{ .Values.github.appId }}
+    {{- with .Values.github.appId }}
+    github-app.id: {{ . }}
     {{- end }}
-    {{- if .Values.github.appName }}
-    github-app.name: {{ .Values.github.appName | quote }}
+    {{- with .Values.github.appName }}
+    github-app.name: {{ . | quote }}
     {{- end }}
-    {{- if .Values.github.privateKey }}
-    github-app.private-key: |-
-{{ .Values.github.privateKey | indent 8 }}
-    {{- end }}
-    {{- if .Values.github.webhookSecret }}
-    github-app.webhook-secret: {{ .Values.github.webhookSecret | quote }}
-    {{- end }}
-    {{- if .Values.github.clientId }}
-    github-app.client-id: {{ .Values.github.clientId | quote }}
-    {{- end }}
-    {{- if .Values.github.clientSecret }}
-    github-app.client-secret: {{ .Values.github.clientSecret | quote }}
+    {{- if not .Values.github.existingSecret }}
+      {{- with .Values.github.privateKey }}
+    github-app.private-key: {{- . | toYaml | indent 4 }}
+      {{- end }}
+      {{- with .Values.github.webhookSecret }}
+    github-app.webhook-secret: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.github.clientId }}
+    github-app.client-id: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.github.clientSecret }}
+    github-app.client-secret: {{ . | quote }}
+      {{- end }}
     {{- end }}
 
     ##########
@@ -484,5 +485,15 @@ data:
     SENTRY_OPTIONS['slack.client-id'] = os.environ.get("SLACK_CLIENT_ID")
     SENTRY_OPTIONS['slack.client-secret'] = os.environ.get("SLACK_CLIENT_SECRET")
     SENTRY_OPTIONS['slack.signing-secret'] = os.environ.get("SLACK_SIGNING_SECRET")
+{{- end }}
+
+{{- if .Values.github.existingSecret }}
+    ##########
+    # Github #
+    ##########
+    SENTRY_OPTIONS['github-app.private-key'] = os.environ.get("GITHUB_APP_PRIVATE_KEY")
+    SENTRY_OPTIONS['github-app.webhook-secret'] = os.environ.get("GITHUB_APP_WEBHOOK_SECRET")
+    SENTRY_OPTIONS['github-app.client-id'] = os.environ.get("GITHUB_APP_CLIENT_ID")
+    SENTRY_OPTIONS['github-app.client-secret'] = os.environ.get("GITHUB_APP_CLIENT_SECRET")
 {{- end }}
 {{ .Values.config.sentryConfPy | indent 4 }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -719,7 +719,20 @@ github: {}
 #   clientId: "xxxxx"
 #   clientSecret: "xxxxx"
 #   privateKey: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpA" !!!! Don't forget a trailing \n
-#   webhookSecret:  "xxxxx`"
+#   webhookSecret:  "xxxxx"
+#
+#   Note: if you use `existingSecret`, all above `clientId`, `clientSecret`, `privateKey`, `webhookSecret`
+#   params would be ignored, because chart will suppose that they are stored in `existingSecret`. So you
+#   must define all required keys and set it at least to empty strings if they are not needed in `existingSecret`
+#   secret (client-id, client-secret, webhook-secret, private-key)
+#
+#   existingSecret: "xxxxx"
+#   existingSecretPrivateKeyKey: ""     # by default "private-key"
+#   existingSecretWebhookSecretKey: ""  # by default "webhook-secret"
+#   existingSecretClientIdKey: ""       # by default "client-id"
+#   existingSecretClientSecretKey: ""   # by default "client-secret"
+#
+#   Reference -> https://docs.sentry.io/product/integrations/source-code-mgmt/github/
 
 # https://developers.google.com/identity/sign-in/web/server-side-flow#step_1_create_a_client_id_and_client_secret
 google: {}


### PR DESCRIPTION
Add possibility to pass `existingSecret` for Github for Sentry helm chart: https://saritasa.atlassian.net/browse/SD-547

P.S. changes are already applied on rocks EKS and everything works ok.